### PR TITLE
Add github CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# See https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @nono will be requested for review when someone opens a pull request.
+*       @nono
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# impact debian packaging files, only sblaisot and not the global
+# owner(s) will be requested for a review.
+debian/*       @sblaisot
+env.template   @sblaisot


### PR DESCRIPTION
CODEOWNERS file describe who "owns" code inside a repository and automatically adds code owners for pull request updating their code.

see [the doc](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/about-code-owners)

Content could be tuned if needed but I ask to be automatically requested for review on any change in the debian subdirectory