### PR TITLE
Small English grammar fix

### DIFF
--- a/lib/move_web/templates/instance/index.html.eex
+++ b/lib/move_web/templates/instance/index.html.eex
@@ -63,7 +63,7 @@
   <% end %>
 
   <p class="u-text u-fz-small u-mb-0 u-mt-1-half">
-    <%= gettext "You cannot access your both Cozy during this export phase. It may take several hours. Don't worry: you will be notified once the export is complete." %>
+    <%= gettext "You cannot access either of your Cozy during this export phase. It may take several hours. Don't worry: you will be notified once the export is complete." %>
   </p>
 </section>
 

--- a/lib/move_web/templates/page/index.html.eex
+++ b/lib/move_web/templates/page/index.html.eex
@@ -2,7 +2,7 @@
   <img class="u-w-auto" src="<%= Routes.static_path(@conn, "/images/truck.svg") %>" alt=""/>
   <h1 class="u-title-h1 u-mt-1 u-ta-center"><%= gettext "Move my Cozy" %></h1>
   <p class="u-text u-w-100 u-mb-0"><%= gettext "By moving your Cozy, you can choose to transfer all your data to a new address or a new host of your choice." %></p>
-  <p class="u-text u-w-100 u-mb-0"><%= gettext "You will not be allowed to access your old and new Cozy during this moving phase. This can take several hours." %></p>
+  <p class="u-text u-w-100 u-mb-0"><%= gettext "You will not be allowed to access either your old or new Cozy during this moving phase. This can take several hours." %></p>
   <p class="u-text u-w-100 u-mb-0"><%= gettext "Once the transfer is completed, your old Cozy will be deleted." %></p>
 </section>
 

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -135,11 +135,11 @@ msgid "Warning"
 msgstr ""
 
 #: lib/move_web/templates/instance/index.html.eex:66
-msgid "You cannot access your both Cozy during this export phase. It may take several hours. Don't worry: you will be notified once the export is complete."
+msgid "You cannot access either of your Cozy during this export phase. It may take several hours. Don't worry: you will be notified once the export is complete."
 msgstr ""
 
 #: lib/move_web/templates/page/index.html.eex:5
-msgid "You will not be allowed to access your old and new Cozy during this moving phase. This can take several hours."
+msgid "You will not be allowed to access either your old or new Cozy during this moving phase. This can take several hours."
 msgstr ""
 
 #: lib/move_web/templates/layout/app.html.eex:13

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -136,11 +136,11 @@ msgid "Warning"
 msgstr ""
 
 #: lib/move_web/templates/instance/index.html.eex:66
-msgid "You cannot access your both Cozy during this export phase. It may take several hours. Don't worry: you will be notified once the export is complete."
+msgid "You cannot access either of your Cozy during this export phase. It may take several hours. Don't worry: you will be notified once the export is complete."
 msgstr ""
 
 #: lib/move_web/templates/page/index.html.eex:5
-msgid "You will not be allowed to access your old and new Cozy during this moving phase. This can take several hours."
+msgid "You will not be allowed to access either your old or new Cozy during this moving phase. This can take several hours."
 msgstr ""
 
 #: lib/move_web/templates/layout/app.html.eex:13

--- a/priv/gettext/fr/LC_MESSAGES/default.po
+++ b/priv/gettext/fr/LC_MESSAGES/default.po
@@ -151,14 +151,14 @@ msgid "Warning"
 msgstr "Attention"
 
 #: lib/move_web/templates/instance/index.html.eex:66
-msgid "You cannot access your both Cozy during this export phase. It may take several hours. Don't worry: you will be notified once the export is complete."
+msgid "You cannot access either of your Cozy during this export phase. It may take several hours. Don't worry: you will be notified once the export is complete."
 msgstr ""
 "Les ancien et nouveau Cozy seront inaccessibles durant cette phase d'export."
 " Cela pourra prendre plusieurs heures. Ne vous inquiétez pas : vous serez "
 "prévenu une fois l'export terminé."
 
 #: lib/move_web/templates/page/index.html.eex:5
-msgid "You will not be allowed to access your old and new Cozy during this moving phase. This can take several hours."
+msgid "You will not be allowed to access either your old or new Cozy during this moving phase. This can take several hours."
 msgstr ""
 "Vos ancien et nouveau Cozy seront inaccessibles durant cette phase de "
 "déménagement. Cela pourra durer plusieurs heures."


### PR DESCRIPTION
To express the fact that none of the Cozy will be available during the
move, we need to use `either` instead of `both` (which would carry the
idea that the user will not be able to access the old and the new Cozy
at the same time).