### PR TITLE
Don't drop privileges for running service hooks

### DIFF
--- a/debian/cozy-move.service
+++ b/debian/cozy-move.service
@@ -13,8 +13,8 @@ EnvironmentFile=/etc/cozy-move/env
 Environment=RELEASE_TMP=/run/cozy-move
 SyslogIdentifier=cozy-move
 ExecStart=/usr/lib/cozy_move/bin/cozy_move start
-ExecStartPost=-/usr/local/sbin/cozy-move-post-start.sh
-ExecStop=-/usr/local/sbin/cozy-move-pre-stop.sh
+ExecStartPost=-+/usr/local/sbin/cozy-move-post-start.sh
+ExecStop=-+/usr/local/sbin/cozy-move-pre-stop.sh
 ExecStop=/usr/lib/cozy_move/bin/cozy_move stop
 ExecRestart=/usr/lib/cozy_move/bin/cozy_move restart
 Restart=always


### PR DESCRIPTION
Currently, service hook scripts post-start and pre-stop are executed as lower privileges user `cozy-move`.
We need those scripts to be executed as root.